### PR TITLE
Added functionality to compress input before upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,14 +125,25 @@ public function main() {
     
     // Upload file to a remote server
     io:ReadableByteChannel|error summaryChannel = io:openReadableFile("<The local data source path>");
-    if(summaryChannel is io:ReadableByteChannel){
+    if (summaryChannel is io:ReadableByteChannel) {
         error? putResponse = ftpClient->put("<The resource path>", summaryChannel);   
-        if(putResponse is error) {
+        if (putResponse is error) {
             log:printError("Error occured in uploading content", putResponse);
             return;
         }
     }
-    
+
+    // Compress and upload file to a remote server
+    io:ReadableByteChannel|error inputChannel = io:openReadableFile("<Local data source path>");
+    if (inputChannel is io:ReadableByteChannel) {
+        // Set the optional boolean flag as 'true' to compress before uploading
+        error? compressedPutResponse = ftpClient->put("<Resource path>", inputChannel, true);   
+        if (compressedPutResponse is error) {
+            log:printError("Error occured in uploading content", compressedPutResponse);
+            return;
+        }
+    }
+
     // Get the size of a remote file
     var sizeResponse = ftpClient->size("<The resource path>");
     if (sizeResponse is int) {

--- a/ftp-utils/src/main/java/org/wso2/ei/b7a/ftp/core/util/FTPConstants.java
+++ b/ftp-utils/src/main/java/org/wso2/ei/b7a/ftp/core/util/FTPConstants.java
@@ -60,5 +60,6 @@ public class FTPConstants {
     public static final String INPUT_CONTENT_IS_FILE_KEY = "isFile";
     public static final String INPUT_CONTENT_FILE_CONTENT_KEY = "fileContent";
     public static final String INPUT_CONTENT_TEXT_CONTENT_KEY = "textContent";
+    public static final String INPUT_CONTENT_COMPRESS_INPUT_KEY = "compressInput";
 
 }

--- a/ftp/src/ftp/Module.md
+++ b/ftp/src/ftp/Module.md
@@ -116,6 +116,17 @@ public function main() {
             return;
         }
     }
+
+    // Compress and upload file to a remote server
+    io:ReadableByteChannel|error inputChannel = io:openReadableFile("<Local data source path>");
+    if (inputChannel is io:ReadableByteChannel) {
+        // Set the optional boolean flag as 'true' to compress before uploading
+        error? compressedPutResponse = ftpClient->put("<Resource path>", inputChannel, true);   
+        if (compressedPutResponse is error) {
+            log:printError("Error occured in uploading content", compressedPutResponse);
+            return;
+        }
+    }
     
     // Get the size of a remote file
     var sizeResponse = ftpClient->size("<The resource path>");

--- a/ftp/src/ftp/client_endpoint.bal
+++ b/ftp/src/ftp/client_endpoint.bal
@@ -62,9 +62,11 @@ public type Client client object {
     #
     # + path - The resource path
     # + content - Content to be written to the file in server
+    # + compressInput - True if file should be compressed before uploading
     # + return - An `error` if failed to establish communication with the FTP server
-    public remote function put(string path, io:ReadableByteChannel|string|xml|json content) returns error? {
-        return put(self, getInputContent(path, content));
+    public remote function put(string path, io:ReadableByteChannel|string|xml|json content,
+                                                                boolean compressInput=false) returns error? {
+        return put(self, getInputContent(path, content, compressInput));
     }
 
     # The `mkdir()` function can be used to create a new direcotry in an FTP server.
@@ -146,9 +148,10 @@ public type ClientEndpointConfig record {|
     SecureSocket? secureSocket = ();
 |};
 
-function getInputContent(string path, io:ReadableByteChannel|string|xml|json content) returns InputContent{
+function getInputContent(string path, io:ReadableByteChannel|string|xml|json content, boolean compressInput=false) returns InputContent{
     InputContent inputContent = {
-        filePath: path
+        filePath: path,
+        compressInput: compressInput
     };
 
     if(content is io:ReadableByteChannel){

--- a/ftp/src/ftp/commons.bal
+++ b/ftp/src/ftp/commons.bal
@@ -81,9 +81,11 @@ public type SecureSocket record {|
 # + isFile - True if input type is a file
 # + fileContent - The content read from the input file, if the input is a file
 # + textContent - The input content, for other input types
+# + compressInput - If true, input will be compressed before upload
 public type InputContent record{|
     string filePath;
     boolean isFile = false;
     io:ReadableByteChannel? fileContent = ();
     string? textContent = ();
+    boolean compressInput = false;
 |};


### PR DESCRIPTION
## Purpose
Added functionality to compress before uploading to FTP server. 

To enable compressing, in the `put()` function, set the optional `compressInput` parameter to true:

`
error? response = clientEP -> put(filePath, inputContent, true);
`

Fixes: #75, https://github.com/wso2/ballerina-integrator/issues/523