### PR TITLE
Avoid packing org.ballerinalang classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The following sections provide you details on how to use the FTP connector.
 
 |                             |           Version           |
 |:---------------------------:|:---------------------------:|
-| Ballerina Language          |            1.0.1            |
+| Ballerina Language          |            1.1.1            |
 
 ## Feature Overview
 

--- a/ftp-compiler-plugin/pom.xml
+++ b/ftp-compiler-plugin/pom.xml
@@ -22,12 +22,12 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>module-ftp</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>ftp-compiler-plugin</artifactId>
-    <version>0.4.1</version>
+    <version>0.4.2</version>
     <packaging>jar</packaging>
     <name>FTP Module - Compiler Validation Utility</name>
     <url>https://ballerina.io/</url>

--- a/ftp-utils/pom.xml
+++ b/ftp-utils/pom.xml
@@ -21,12 +21,12 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>module-ftp</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
-    <version>0.4.1</version>
+    <version>0.4.2</version>
     <artifactId>ftp-utils</artifactId>
     <packaging>jar</packaging>
     <name>FTP Module - Java utility library</name>

--- a/ftp-utils/pom.xml
+++ b/ftp-utils/pom.xml
@@ -119,6 +119,16 @@
                                     </excludes>
                                 </filter>
                             </filters>
+                            <artifactSet>
+                                <excludes>
+                                    <exclude>org.ballerinalang:ballerina-runtime</exclude>
+                                    <exclude>org.ballerinalang:ballerina-lang</exclude>
+                                    <exclude>org.ballerinalang:ballerina-io</exclude>
+                                    <exclude>org.mockftpserver:MockFtpServer</exclude>
+                                    <exclude>org.slf4j:slf4j-api</exclude>
+                                    <exclude>org.slf4j:slf4j-log4j12</exclude>
+                                </excludes>
+                            </artifactSet>
                         </configuration>
                     </execution>
                 </executions>

--- a/ftp-utils/src/main/java/org/wso2/ei/b7a/ftp/core/util/FTPConstants.java
+++ b/ftp-utils/src/main/java/org/wso2/ei/b7a/ftp/core/util/FTPConstants.java
@@ -39,7 +39,7 @@ public class FTPConstants {
     public static final String PROPERTY_MAP = "map";
     public static final String FTP_ORG_NAME = "wso2";
     public static final String FTP_MODULE_NAME = "ftp";
-    public static final String FTP_MODULE_VERSION = "0.4.1";
+    public static final String FTP_MODULE_VERSION = "0.4.2";
     public static final String FTP_LISTENER = "Listener";
     public static final String FTP_SERVER_EVENT = "WatchEvent";
     public static final String FTP_FILE_INFO = "FileInfo";

--- a/ftp/Ballerina.lock
+++ b/ftp/Ballerina.lock
@@ -1,9 +1,9 @@
 org_name = "wso2"
-version = "0.4.1"
+version = "0.4.2"
 lockfile_version = "1.0.0"
-ballerina_version = "1.1.0"
+ballerina_version = "1.1.1"
 
-[[imports."wso2/ftp:0.4.1"]]
+[[imports."wso2/ftp:0.4.2"]]
 org_name = "ballerinax"
 name = "java"
 version = "0.0.0"

--- a/ftp/Ballerina.toml
+++ b/ftp/Ballerina.toml
@@ -1,6 +1,6 @@
 [project]
 org-name= "wso2"
-version= "0.4.1"
+version= "0.4.2"
 license= ["Apache-2.0"]
 authors= ["WSO2"]
 keywords= ["ftp"]
@@ -13,7 +13,7 @@ target = "java8"
 
     [[platform.libraries]]
     module = "utils/ftp-utils"
-    path = "../ftp-utils/target/ftp-utils-module-0.4.1.jar"
+    path = "../ftp-utils/target/ftp-utils-module-0.4.2.jar"
     artifactId = "wso2-ftp"
-    version = "0.4.1"
+    version = "0.4.2"
     groupId = "org.wso2.ei"

--- a/ftp/pom.xml
+++ b/ftp/pom.xml
@@ -22,13 +22,13 @@
     <parent>
         <artifactId>module-ftp</artifactId>
         <groupId>org.wso2.ei</groupId>
-        <version>0.4.1</version>
+        <version>0.4.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>ftp</artifactId>
-    <version>0.4.1</version>
+    <version>0.4.2</version>
     <packaging>pom</packaging>
     <name>FTP Module - Ballerina Implementation</name>
     <url>https://ballerina.io/</url>

--- a/ftp/src/ftp/Module.md
+++ b/ftp/src/ftp/Module.md
@@ -32,7 +32,7 @@ For instance, if the listener gets invoked for text files, the value `(.*).txt` 
 
 |                             |           Version           |
 |:---------------------------:|:---------------------------:|
-| Ballerina Language          |            1.1.0            |
+| Ballerina Language          |            1.1.1            |
 
 ## Samples
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <groupId>org.wso2.ei</groupId>
     <artifactId>module-ftp</artifactId>
     <packaging>pom</packaging>
-    <version>0.4.1</version>
+    <version>0.4.2</version>
     <name>Ballerina - FTP Module Parent</name>
 
     <url>https://ballerina.io/</url>
@@ -191,7 +191,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <ballerina.version>1.1.0</ballerina.version>
-        <module.ftp.version>0.4.1</module.ftp.version>
+        <module.ftp.version>0.4.2</module.ftp.version>
 
         <file.transport.version>6.0.57</file.transport.version>
         <jsch.version>0.1.54</jsch.version>


### PR DESCRIPTION
## Purpose
This PR will avoid packing org.ballerinalang classes into Ballerina FTP connector.

Fixes: https://github.com/wso2-ballerina/module-ftp/issues/82